### PR TITLE
fix: typo in getting started

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ This is a generic client, because schemas for input, output, and configurations 
 ## ACP SDK CLI
 
 ```
-$ cd agtncy_acp
+$ cd agntcy_acp
 $ poetry run acp --help
 Usage: acp [OPTIONS] COMMAND [ARGS]...
 


### PR DESCRIPTION
This fixes a typo in Getting started document