### PR TITLE
fix: use api bridge semantic routing

### DIFF
--- a/agntcy_acp/langgraph/api_bridge.py
+++ b/agntcy_acp/langgraph/api_bridge.py
@@ -41,6 +41,9 @@ class APIBridgeAgentNode(acp_node.ACPNode):
         self.hostname = hostname
         self.apikey = apikey
         self.service_name = service_name
+        # API Bridge agent requires the endpoint to end with '/'
+        if not self.service_name.endswith('/'):
+            self.service_name += '/'
         self.inputType = input_type
         self.outputType = output_type
         self.inputPath = input_path
@@ -50,17 +53,10 @@ class APIBridgeAgentNode(acp_node.ACPNode):
     def invoke(self, state: Any, config: RunnableConfig) -> Any:
         api_bridge_input = self._extract_input(state)
 
-        api_bridge_input.query = (
-            "Please use content-type application/json." + api_bridge_input.query
-        )
-
         # TODO: Merge config with runnable config
         headers = {
-            "Accept": None,
             "Authorization": f"Bearer {self.service_api_key}",
-            "Accept-Encoding": None,
-            "Content-Type": "text/plain",
-            "X-Nl-Query-Enabled": "yes",
+            "Content-Type": "application/nlq",
         }
         r = requests.post(
             f"{self.hostname}/{self.service_name}",

--- a/examples/marketing-campaign/src/marketing_campaign/app.py
+++ b/examples/marketing-campaign/src/marketing_campaign/app.py
@@ -129,7 +129,7 @@ def build_graph() -> CompiledStateGraph:
         output_path="sendgrid_state.output",
         service_api_key=sendgrid_api_key,
         hostname=SENDGRID_HOST,
-        service_name="sendgrid/v3/mail/send"
+        service_name="sendgrid"
     )
 
     # Create the state graph


### PR DESCRIPTION
API Bridge Node (`APIBridgeAgentNode`) now uses the semantic routing feature of API Bridge Agent.

You have to specify the service name as specified in API Bridge agent configuration (ex: sendgrid, github, jira) instead of the full API URL.