### PR TITLE
feat: Acp node thread support

### DIFF
--- a/agntcy_acp/acp_v0/async_client/api/thread_runs_api.py
+++ b/agntcy_acp/acp_v0/async_client/api/thread_runs_api.py
@@ -2513,7 +2513,7 @@ class ThreadRunsApi:
         # Handle errors separately
         if response_data.status != 200:
             await response_data.read()
-            return self.api_client.response_deserialize(
+            yield self.api_client.response_deserialize(
                 response_data=response_data,
                 response_types_map=_response_types_map,
             ).data
@@ -2596,7 +2596,7 @@ class ThreadRunsApi:
         # Handle errors separately
         if response_data.status != 200:
             await response_data.read()
-            return self.api_client.response_deserialize(
+            yield self.api_client.response_deserialize(
                 response_data=response_data,
                 response_types_map=_response_types_map,
             )

--- a/agntcy_acp/acp_v0/async_client/api/thread_runs_api.py
+++ b/agntcy_acp/acp_v0/async_client/api/thread_runs_api.py
@@ -15,7 +15,7 @@
 
 import warnings
 from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, AsyncIterator
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictBool, StrictInt, StrictStr, field_validator
@@ -25,10 +25,12 @@ from agntcy_acp.acp_v0.models.run_create_stateful import RunCreateStateful
 from agntcy_acp.acp_v0.models.run_output_stream import RunOutputStream
 from agntcy_acp.acp_v0.models.run_stateful import RunStateful
 from agntcy_acp.acp_v0.models.run_wait_response_stateful import RunWaitResponseStateful
+from agntcy_acp.acp_v0.models.stream_event_payload import StreamEventPayload
 
 from agntcy_acp.acp_v0.async_client.api_client import ApiClient, RequestSerialized
 from agntcy_acp.acp_v0.api_response import ApiResponse
 from agntcy_acp.acp_v0.async_client.rest import RESTResponseType
+from agntcy_acp.server_side_events import sse_astream
 
 
 class ThreadRunsApi:
@@ -42,6 +44,7 @@ class ThreadRunsApi:
         if api_client is None:
             api_client = ApiClient.get_default()
         self.api_client = api_client
+        self.stream_chunk_size = 4096
 
 
     @validate_call
@@ -373,7 +376,7 @@ class ThreadRunsApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> RunOutputStream:
+    ) -> AsyncIterator[RunOutputStream]:
         """Create a run on a thread and stream its output
 
         Create a run on a thread and join its output stream. See 'GET /runs/{run_id}/stream' for details on the return values.
@@ -414,7 +417,6 @@ class ThreadRunsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RunOutputStream",
             '404': "str",
             '409': "str",
             '422': "str",
@@ -423,11 +425,22 @@ class ThreadRunsApi:
             *_param,
             _request_timeout=_request_timeout
         )
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        ).data
+        # Handle errors separately
+        if response_data.status != 200:
+            await response_data.read()
+            yield self.api_client.response_deserialize(
+                response_data=response_data,
+                response_types_map=_response_types_map,
+            ).data
+        else:
+            # Handle SSE data
+            stream = response_data.response.content.iter_chunked(self.stream_chunk_size)
+            async for event in sse_astream(stream):
+                yield RunOutputStream(
+                    id=event.last_event_id,
+                    event=event.event_type,
+                    data=StreamEventPayload.from_json(event.event_data),
+                )
 
 
     @validate_call
@@ -447,7 +460,7 @@ class ThreadRunsApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[RunOutputStream]:
+    ) -> AsyncIterator[ApiResponse[RunOutputStream]]:
         """Create a run on a thread and stream its output
 
         Create a run on a thread and join its output stream. See 'GET /runs/{run_id}/stream' for details on the return values.
@@ -488,7 +501,6 @@ class ThreadRunsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RunOutputStream",
             '404': "str",
             '409': "str",
             '422': "str",
@@ -497,11 +509,22 @@ class ThreadRunsApi:
             *_param,
             _request_timeout=_request_timeout
         )
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        )
+        # Handle errors separately
+        if response_data.status != 200:
+            await response_data.read()
+            yield self.api_client.response_deserialize(
+                response_data=response_data,
+                response_types_map=_response_types_map,
+            )
+        else:
+            # Handle SSE data
+            stream = response_data.response.content.iter_chunked(self.stream_chunk_size)
+            async for event in sse_astream(stream):
+                yield RunOutputStream(
+                    id=event.last_event_id,
+                    event=event.event_type,
+                    data=StreamEventPayload.from_json(event.event_data),
+                )
 
 
     @validate_call
@@ -2439,7 +2462,7 @@ class ThreadRunsApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> RunOutputStream:
+    ) -> AsyncIterator[RunOutputStream]:
         """Stream output from Run
 
         Join the output stream of an existing run. See 'GET /runs/{run_id}/stream' for details on the return values.
@@ -2480,7 +2503,6 @@ class ThreadRunsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RunOutputStream",
             '404': "str",
             '422': "str",
         }
@@ -2488,11 +2510,22 @@ class ThreadRunsApi:
             *_param,
             _request_timeout=_request_timeout
         )
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        ).data
+        # Handle errors separately
+        if response_data.status != 200:
+            await response_data.read()
+            return self.api_client.response_deserialize(
+                response_data=response_data,
+                response_types_map=_response_types_map,
+            ).data
+        else:
+            # Handle SSE data
+            stream = response_data.response.content.iter_chunked(self.stream_chunk_size)
+            async for event in sse_astream(stream):
+                yield RunOutputStream(
+                    id=event.last_event_id,
+                    event=event.event_type,
+                    data=StreamEventPayload.from_json(event.event_data),
+                )
 
 
     @validate_call
@@ -2512,7 +2545,7 @@ class ThreadRunsApi:
         _content_type: Optional[StrictStr] = None,
         _headers: Optional[Dict[StrictStr, Any]] = None,
         _host_index: Annotated[StrictInt, Field(ge=0, le=0)] = 0,
-    ) -> ApiResponse[RunOutputStream]:
+    ) -> AsyncIterator[ApiResponse[RunOutputStream]]:
         """Stream output from Run
 
         Join the output stream of an existing run. See 'GET /runs/{run_id}/stream' for details on the return values.
@@ -2553,7 +2586,6 @@ class ThreadRunsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RunOutputStream",
             '404': "str",
             '422': "str",
         }
@@ -2561,11 +2593,22 @@ class ThreadRunsApi:
             *_param,
             _request_timeout=_request_timeout
         )
-        await response_data.read()
-        return self.api_client.response_deserialize(
-            response_data=response_data,
-            response_types_map=_response_types_map,
-        )
+        # Handle errors separately
+        if response_data.status != 200:
+            await response_data.read()
+            return self.api_client.response_deserialize(
+                response_data=response_data,
+                response_types_map=_response_types_map,
+            )
+        # Handle SSE data
+        else:
+            stream = response_data.response.content.iter_chunked(self.stream_chunk_size)
+            async for event in sse_astream(stream):
+                yield RunOutputStream(
+                    id=event.last_event_id,
+                    event=event.event_type,
+                    data=StreamEventPayload.from_json(event.event_data),
+                )
 
 
     @validate_call

--- a/agntcy_acp/acp_v0/models/content.py
+++ b/agntcy_acp/acp_v0/models/content.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import pprint
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import model_serializer
 from typing import Any, List, Optional
 from agntcy_acp.acp_v0.models.content_one_of_inner import ContentOneOfInner
 from pydantic import StrictStr, Field
@@ -128,6 +129,7 @@ class Content(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
+    @model_serializer()
     def to_dict(self) -> Optional[Union[Dict[str, Any], List[ContentOneOfInner], str]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:

--- a/agntcy_acp/acp_v0/models/content_one_of_inner.py
+++ b/agntcy_acp/acp_v0/models/content_one_of_inner.py
@@ -20,6 +20,7 @@ import json
 import pprint
 import re  # noqa: F401
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import model_serializer
 from typing import Optional
 from agntcy_acp.acp_v0.models.message_any_block import MessageAnyBlock
 from agntcy_acp.acp_v0.models.message_text_block import MessageTextBlock
@@ -119,6 +120,7 @@ class ContentOneOfInner(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
+    @model_serializer()
     def to_dict(self) -> Optional[Union[Dict[str, Any], MessageAnyBlock, MessageTextBlock]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:

--- a/agntcy_acp/acp_v0/models/run_create_stateful.py
+++ b/agntcy_acp/acp_v0/models/run_create_stateful.py
@@ -88,7 +88,7 @@ class RunCreateStateful(BaseModel):
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
         # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/agntcy_acp/acp_v0/models/run_create_stateless.py
+++ b/agntcy_acp/acp_v0/models/run_create_stateless.py
@@ -87,7 +87,7 @@ class RunCreateStateless(BaseModel):
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
         # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/agntcy_acp/acp_v0/models/run_output.py
+++ b/agntcy_acp/acp_v0/models/run_output.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import pprint
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import model_serializer
 from typing import Any, List, Optional
 from agntcy_acp.acp_v0.models.run_error import RunError
 from agntcy_acp.acp_v0.models.run_interrupt import RunInterrupt
@@ -138,6 +139,7 @@ class RunOutput(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
+    @model_serializer()
     def to_dict(self) -> Optional[Union[Dict[str, Any], RunError, RunInterrupt, RunResult]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:

--- a/agntcy_acp/acp_v0/models/run_stateful.py
+++ b/agntcy_acp/acp_v0/models/run_stateful.py
@@ -54,7 +54,7 @@ class RunStateful(BaseModel):
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
         # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/agntcy_acp/acp_v0/models/run_wait_response_stateful.py
+++ b/agntcy_acp/acp_v0/models/run_wait_response_stateful.py
@@ -48,7 +48,7 @@ class RunWaitResponseStateful(BaseModel):
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
         # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/agntcy_acp/acp_v0/models/run_wait_response_stateless.py
+++ b/agntcy_acp/acp_v0/models/run_wait_response_stateless.py
@@ -48,7 +48,7 @@ class RunWaitResponseStateless(BaseModel):
     def to_json(self) -> str:
         """Returns the JSON representation of the model using alias"""
         # TODO: pydantic v2: use .model_dump_json(by_alias=True, exclude_unset=True) instead
-        return json.dumps(self.to_dict())
+        return self.model_dump_json(by_alias=True, exclude_unset=True)
 
     @classmethod
     def from_json(cls, json_str: str) -> Optional[Self]:

--- a/agntcy_acp/acp_v0/models/stream_event_payload.py
+++ b/agntcy_acp/acp_v0/models/stream_event_payload.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import pprint
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import model_serializer
 from typing import Any, List, Optional
 from agntcy_acp.acp_v0.models.custom_run_result_update import CustomRunResultUpdate
 from agntcy_acp.acp_v0.models.value_run_result_update import ValueRunResultUpdate
@@ -124,6 +125,7 @@ class StreamEventPayload(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
+    @model_serializer()
     def to_dict(self) -> Optional[Union[Dict[str, Any], CustomRunResultUpdate, ValueRunResultUpdate]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:

--- a/agntcy_acp/acp_v0/models/stream_mode.py
+++ b/agntcy_acp/acp_v0/models/stream_mode.py
@@ -20,6 +20,7 @@ import json
 import pprint
 import re  # noqa: F401
 from pydantic import BaseModel, ConfigDict, Field, StrictStr, ValidationError, field_validator
+from pydantic import model_serializer
 from typing import List, Optional
 from agntcy_acp.acp_v0.models.streaming_mode import StreamingMode
 from typing import Union, Any, List, Set, TYPE_CHECKING, Optional, Dict
@@ -127,6 +128,7 @@ class StreamMode(BaseModel):
         else:
             return json.dumps(self.actual_instance)
 
+    @model_serializer()
     def to_dict(self) -> Optional[Union[Dict[str, Any], List[StreamingMode], StreamingMode]]:
         """Returns the dict representation of the actual instance"""
         if self.actual_instance is None:

--- a/agntcy_acp/manifest/generator.py
+++ b/agntcy_acp/manifest/generator.py
@@ -232,7 +232,8 @@ def generate_agent_models(descriptor: AgentACPDescriptor, path: str, model_file_
         output=Path(modelspath),
         disable_timestamp=True,
         custom_file_header=f"# Generated from ACP Descriptor {descriptor.metadata.ref.name} using datamodel_code_generator.",
-        keep_model_order=True
+        keep_model_order=True,
+        use_double_quotes=True, # match ruff formatting
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,10 @@ def default_agent_id():
     return "bogus-agent-id"
 
 @pytest.fixture
+def default_thread_id():
+    return 'd379d156-560b-4c97-ba04-0e88c26fe697'
+
+@pytest.fixture
 def default_api_key():
     return "bogus-api-key"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,12 @@ import pytest
 import agntcy_acp
 from agntcy_acp import ApiResponse
 from agntcy_acp.models import (
+    RunCreateStateful,
     RunCreateStateless,
     RunOutput,
     RunOutputStream,
     RunResult,
+    RunStateful,
     RunStateless,
     RunStatus,
     StreamEventPayload,
@@ -23,54 +25,77 @@ from agntcy_acp.models import (
 def default_agent_id():
     return "bogus-agent-id"
 
+
 @pytest.fixture
 def default_thread_id():
-    return 'd379d156-560b-4c97-ba04-0e88c26fe697'
+    return "d379d156-560b-4c97-ba04-0e88c26fe697"
+
 
 @pytest.fixture
 def default_api_key():
     return "bogus-api-key"
 
+
 @pytest.fixture
 def default_run_stateless_response(default_agent_id) -> RunStateless:
     init_run_id = "bugus-run-id"
     return RunStateless(
-        run_id=init_run_id, 
-        agent_id=default_agent_id, 
+        run_id=init_run_id,
+        agent_id=default_agent_id,
         creation=RunCreateStateless(agent_id=default_agent_id),
         status=RunStatus.SUCCESS,
         created_at=datetime.datetime.now(),
         updated_at=datetime.datetime.now(),
     )
 
+
+@pytest.fixture
+def default_run_stateful_response(default_agent_id) -> RunStateful:
+    init_run_id = "bugus-run-id"
+    return RunStateful(
+        run_id=init_run_id,
+        agent_id=default_agent_id,
+        creation=RunCreateStateful(agent_id=default_agent_id),
+        status=RunStatus.SUCCESS,
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+
+
 @pytest.fixture
 def default_run_output() -> RunOutput:
-    return RunOutput(RunResult(
-        type="result",
-        values={
-            "key": "value",
-        }
-    ))
+    return RunOutput(
+        RunResult(
+            type="result",
+            values={
+                "key": "value",
+            },
+        )
+    )
+
 
 @pytest.fixture
 def default_run_output_stream(default_run_stateless_response) -> RunOutputStream:
     return RunOutputStream(
         id="1",
         event="agent_event",
-        data=StreamEventPayload(ValueRunResultUpdate(
-            type="values",
-            run_id = default_run_stateless_response.run_id,
-            status="success",
-            values = {
-                "key": "value",
-            }
-        )),
+        data=StreamEventPayload(
+            ValueRunResultUpdate(
+                type="values",
+                run_id=default_run_stateless_response.run_id,
+                status="success",
+                values={
+                    "key": "value",
+                },
+            )
+        ),
     )
+
 
 @pytest.fixture
 def mock_async_api_client(
-    default_agent_id, 
-    default_api_key, 
+    default_agent_id,
+    default_api_key,
     monkeypatch,
 ):
     init_run_id = "bugus-run-id"
@@ -104,27 +129,39 @@ def mock_async_api_client(
     ):
         assert header_params is not None
         assert header_params["x-api-key"] == default_api_key
-        return RESTResponseAsync(status=200, body="""
+        return RESTResponseAsync(
+            status=200,
+            body="""
     run_id: 1234-5678-90123
-    """)
+    """,
+        )
+
     monkeypatch.setattr(agntcy_acp.AsyncApiClient, "call_api", mock_call_api)
 
     # Make sure data is deserialized
     def mock_response_deserialize(
         self,
-        response_data, 
-        response_types_map = None,
+        response_data,
+        response_types_map=None,
     ):
         run = RunStateless(
-            run_id=init_run_id, 
-            agent_id=default_agent_id, 
+            run_id=init_run_id,
+            agent_id=default_agent_id,
             creation=RunCreateStateless(agent_id=default_agent_id),
             status=RunStatus.SUCCESS,
             created_at=datetime.datetime.now(),
             updated_at=datetime.datetime.now(),
         )
-        return ApiResponse[RunStateless](status_code=200, data=run, raw_data=run.model_dump_json(exclude_unset=True).encode())
-    monkeypatch.setattr(agntcy_acp.AsyncApiClient, "response_deserialize", mock_response_deserialize)
+        return ApiResponse[RunStateless](
+            status_code=200,
+            data=run,
+            raw_data=run.model_dump_json(exclude_unset=True).encode(),
+        )
+
+    monkeypatch.setattr(
+        agntcy_acp.AsyncApiClient, "response_deserialize", mock_response_deserialize
+    )
+
 
 @pytest.fixture
 def mock_sync_api_client(
@@ -159,28 +196,39 @@ def mock_sync_api_client(
         header_params=None,
         body=None,
         post_params=None,
-        _request_timeout=None,        
+        _request_timeout=None,
     ):
         assert header_params is not None
         assert header_params["x-api-key"] == default_api_key
-        return RESTResponse(status=200, body="""
+        return RESTResponse(
+            status=200,
+            body="""
     run_id: 1234-5678-90123
-    """)
+    """,
+        )
+
     monkeypatch.setattr(agntcy_acp.ApiClient, "call_api", mock_call_api)
 
     # Make sure data is deserialized
     def mock_response_deserialize(
-        self, 
-        response_data, 
-        response_types_map = None,
+        self,
+        response_data,
+        response_types_map=None,
     ):
         run = RunStateless(
-            run_id=init_run_id, 
-            agent_id=default_agent_id, 
+            run_id=init_run_id,
+            agent_id=default_agent_id,
             creation=RunCreateStateless(agent_id=default_agent_id),
             status=RunStatus.SUCCESS,
             created_at=datetime.datetime.now(),
             updated_at=datetime.datetime.now(),
         )
-        return ApiResponse[RunStateless](status_code=200, data=run, raw_data=run.model_dump_json(exclude_unset=True).encode())
-    monkeypatch.setattr(agntcy_acp.ApiClient, "response_deserialize", mock_response_deserialize)
+        return ApiResponse[RunStateless](
+            status_code=200,
+            data=run,
+            raw_data=run.model_dump_json(exclude_unset=True).encode(),
+        )
+
+    monkeypatch.setattr(
+        agntcy_acp.ApiClient, "response_deserialize", mock_response_deserialize
+    )

--- a/tests/test_acp_async_client.py
+++ b/tests/test_acp_async_client.py
@@ -13,11 +13,18 @@ from agntcy_acp import ApiClientConfiguration, AsyncACPClient, AsyncApiClient
 from agntcy_acp.models import (
     RunCreateStateful,
     RunCreateStateless,
+    RunOutput,
+    RunResult,
     RunSearchRequest,
+    RunStateful,
     RunStateless,
+    RunWaitResponseStateful,
+    RunWaitResponseStateless,
 )
 
 ListRunStateless = RootModel[List[RunStateless]]
+ListRunStateful = RootModel[List[RunStateful]]
+
 
 def mock_response_api_client(
     api_client: AsyncApiClient,
@@ -33,15 +40,14 @@ def mock_response_api_client(
                 "GET",
                 {},
             )
-            sse_list = [
-                ":this is a test feed\nid: 1\n".encode(),
-                "event: agent_event\n".encode(),
-            ] + [
-                f"data: {line}\n".encode()
-                for line in body.splitlines()
-            ] + [
-                "\n".encode()
-            ]
+            sse_list = (
+                [
+                    ":this is a test feed\nid: 1\n".encode(),
+                    "event: agent_event\n".encode(),
+                ]
+                + [f"data: {line}\n".encode() for line in body.splitlines()]
+                + ["\n".encode()]
+            )
             print(sse_list)
 
             self.response = ClientResponse(
@@ -55,7 +61,7 @@ def mock_response_api_client(
                 loop=cur_loop,
                 session=None,
             )
-            stream=StreamReader(
+            stream = StreamReader(
                 protocol=BaseProtocol(loop=cur_loop),
                 limit=100,
                 loop=cur_loop,
@@ -98,83 +104,212 @@ def mock_response_api_client(
             body = response.to_json()
         else:
             body = response.model_dump_json(by_alias=True, exclude_unset=True)
-        
+
         return RESTResponseAsync(status=200, body=body)
 
     monkeypatch.setattr(api_client, "call_api", mock_call_api)
 
 
-async def test_acp_client_stateless_runs_api(default_api_key, default_agent_id, default_run_stateless_response, monkeypatch):
+async def test_acp_client_stateless_runs_api(
+    default_api_key, default_agent_id, default_run_stateless_response, monkeypatch
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
     run_response = default_run_stateless_response
+    run_output = RunOutput(
+        RunResult(
+            type="result",
+            values={
+                "key": "value",
+            },
+        )
+    )
 
     async with AsyncACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, run_response, default_api_key, monkeypatch)
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
 
-        response = await client.create_stateless_run(run_create_stateless=RunCreateStateless(agent_id=default_agent_id))
+        response = await client.create_stateless_run(
+            run_create_stateless=RunCreateStateless(agent_id=default_agent_id)
+        )
         assert response is not None
+        assert response.agent_id == run_response.agent_id
         assert response.run_id == run_response.run_id
-        run_id = response.run_id
+        assert response.status == run_response.status
 
+        run_id = response.run_id
         response = await client.get_stateless_run(run_id)
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
         assert response is not None
 
+        mock_response_api_client(
+            client.api_client,
+            RunWaitResponseStateless(run=run_response, output=run_output),
+            default_api_key,
+            monkeypatch,
+        )
         response = await client.wait_for_stateless_run_output(run_id)
         assert response is not None
+        assert response.run is not None
+        assert response.output is not None
+        assert response.run.agent_id == run_response.agent_id
+        assert response.run.run_id == run_response.run_id
+        assert response.run.status == run_response.status
+        assert response.output.actual_instance.type == run_output.actual_instance.type
 
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
         response = await client.resume_stateless_run(run_id, {})
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
 
         list_response = ListRunStateless.model_validate([run_response])
-        mock_response_api_client(client.api_client, list_response, default_api_key, monkeypatch)
-
-        response = await client.search_stateless_runs(RunSearchRequest(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client, list_response, default_api_key, monkeypatch
+        )
+        response = await client.search_stateless_runs(
+            RunSearchRequest(agent_id=default_agent_id)
+        )
         assert response is not None
+        assert len(response) == 1
 
-        mock_response_api_client(client.api_client, run_response, default_api_key, monkeypatch)
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
+        response = await client.delete_stateless_run(run_id)
+        assert response is None
 
-        await client.delete_stateless_run(run_id)
 
-
-async def test_acp_client_stream_stateless_runs_api(default_api_key, default_agent_id, default_run_output_stream, monkeypatch):
+async def test_acp_client_stream_stateless_runs_api(
+    default_api_key, default_agent_id, default_run_output_stream, monkeypatch
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
 
     async with AsyncACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, default_run_output_stream.data, default_api_key, monkeypatch)
-        stream = client.create_and_stream_stateless_run_output(run_create_stateless=RunCreateStateless(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client,
+            default_run_output_stream.data,
+            default_api_key,
+            monkeypatch,
+        )
+        stream = client.create_and_stream_stateless_run_output(
+            run_create_stateless=RunCreateStateless(agent_id=default_agent_id)
+        )
         async for response in stream:
             assert response is not None
-            assert response.data.actual_instance.run_id == default_run_output_stream.data.actual_instance.run_id
+            assert (
+                response.data.actual_instance.run_id
+                == default_run_output_stream.data.actual_instance.run_id
+            )
 
-async def test_acp_client_thread_run_api(mock_async_api_client, default_api_key, default_agent_id, default_thread_id):
+
+async def test_acp_client_thread_run_api(
+    default_api_key,
+    default_run_stateful_response,
+    default_agent_id,
+    default_thread_id,
+    monkeypatch,
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
     thread_id = default_thread_id
+    run_response = default_run_stateful_response
+    run_output = RunOutput(
+        RunResult(
+            type="result",
+            values={
+                "key": "value",
+            },
+        )
+    )
 
-    async with AsyncApiClient(config) as api_client:
-        client = AsyncACPClient(api_client)
-
-        response = await client.create_thread_run(thread_id=thread_id, run_create_stateful=RunCreateStateful(agent_id=default_agent_id))
+    async with AsyncACPClient(configuration=config) as client:
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
+        response = await client.create_thread_run(
+            thread_id=thread_id,
+            run_create_stateful=RunCreateStateful(agent_id=default_agent_id),
+        )
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
+
         run_id = response.run_id
-
         response = await client.get_thread_run(thread_id=thread_id, run_id=run_id)
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
         assert response is not None
 
-        response = await client.wait_for_thread_run_output(thread_id=thread_id, run_id=run_id)
+        mock_response_api_client(
+            client.api_client,
+            RunWaitResponseStateful(run=run_response, output=run_output),
+            default_api_key,
+            monkeypatch,
+        )
+        response = await client.wait_for_thread_run_output(
+            thread_id=thread_id, run_id=run_id
+        )
         assert response is not None
+        assert response.run is not None
+        assert response.output is not None
+        assert response.run.agent_id == run_response.agent_id
+        assert response.run.run_id == run_response.run_id
+        assert response.run.status == run_response.status
+        assert response.output.actual_instance.type == run_output.actual_instance.type
 
-        response = await client.resume_thread_run(thread_id=thread_id, run_id=run_id, body={})
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
+        response = await client.resume_thread_run(
+            thread_id=thread_id, run_id=run_id, body={}
+        )
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
+
+        list_response = ListRunStateful.model_validate([run_response])
+        mock_response_api_client(
+            client.api_client, list_response, default_api_key, monkeypatch
+        )
+        response = await client.list_thread_runs(thread_id=thread_id)
+        assert response is not None
+        assert len(response) == 1
 
         response = await client.delete_thread_run(thread_id=thread_id, run_id=run_id)
-        assert response is not None
+        assert response is None
 
-async def test_acp_client_stream_thread_run_api(default_api_key, default_agent_id, default_run_output_stream, default_thread_id, monkeypatch):
+
+async def test_acp_client_stream_thread_run_api(
+    default_api_key,
+    default_agent_id,
+    default_run_output_stream,
+    default_thread_id,
+    monkeypatch,
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
 
     async with AsyncACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, default_run_output_stream.data, default_api_key, monkeypatch)
-        stream = client.create_and_stream_thread_run_output(thread_id=default_thread_id, run_create_stateful=RunCreateStateful(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client,
+            default_run_output_stream.data,
+            default_api_key,
+            monkeypatch,
+        )
+        stream = client.create_and_stream_thread_run_output(
+            thread_id=default_thread_id,
+            run_create_stateful=RunCreateStateful(agent_id=default_agent_id),
+        )
         async for response in stream:
             assert response is not None
-            assert response.data.actual_instance.run_id == default_run_output_stream.data.actual_instance.run_id
+            assert (
+                response.data.actual_instance.run_id
+                == default_run_output_stream.data.actual_instance.run_id
+            )

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -145,11 +145,18 @@ def test_acp_client_thread_run_api(mock_sync_api_client, default_api_key, defaul
         response = client.wait_for_thread_run_output(thread_id=thread_id, run_id=run_id)
         assert response is not None
 
-        response = client.stream_thread_run_output(thread_id=thread_id, run_id=run_id)
-        assert response is not None
-
         response = client.resume_thread_run(thread_id=thread_id, run_id=run_id, body={})
         assert response is not None
 
         response = client.delete_thread_run(thread_id=thread_id, run_id=run_id)
         assert response is not None
+
+def test_acp_client_stream_thread_run_api(default_api_key, default_agent_id, default_run_output_stream, default_thread_id, monkeypatch):
+    config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
+
+    with ACPClient(configuration=config) as client:
+        mock_response_api_client(client.api_client, default_run_output_stream.data, default_api_key, monkeypatch)
+        stream = client.create_and_stream_thread_run_output(thread_id=default_thread_id, run_create_stateful=RunCreateStateful(agent_id=default_agent_id))
+        for response in stream:
+            assert response is not None
+            assert response.data.actual_instance.run_id == default_run_output_stream.data.actual_instance.run_id

--- a/tests/test_acp_client.py
+++ b/tests/test_acp_client.py
@@ -11,11 +11,18 @@ from agntcy_acp import ACPClient, ApiClient, ApiClientConfiguration
 from agntcy_acp.models import (
     RunCreateStateful,
     RunCreateStateless,
+    RunOutput,
+    RunResult,
     RunSearchRequest,
+    RunStateful,
     RunStateless,
+    RunWaitResponseStateful,
+    RunWaitResponseStateless,
 )
 
 ListRunStateless = RootModel[List[RunStateless]]
+ListRunStateful = RootModel[List[RunStateful]]
+
 
 def mock_response_api_client(
     api_client: ApiClient,
@@ -26,32 +33,28 @@ def mock_response_api_client(
     class RESTResponse(io.IOBase):
         def __init__(self, status, body: str) -> None:
             body_bytes = body.encode()
-            self.response = HTTPResponse(
-                body = body_bytes
-            )
+            self.response = HTTPResponse(body=body_bytes)
             self.status = status
             self.reason = None
             self.data = body_bytes
 
             def mock_stream(
-                amt: int | None = 2**16, 
+                amt: int | None = 2**16,
                 decode_content: bool | None = None,
-                body = body,
-            ) -> Generator[bytes,None,None]:
-                sse_list = [
-                    ":this is a test feed\nid: 1\n".encode(),
-                    "event: agent_event\n".encode(),
-                ] + [
-                    f"data: {line}\n".encode()
-                    for line in body.splitlines()
-                ] + [
-                    "\n".encode()
-                ]
+                body=body,
+            ) -> Generator[bytes, None, None]:
+                sse_list = (
+                    [
+                        ":this is a test feed\nid: 1\n".encode(),
+                        "event: agent_event\n".encode(),
+                    ]
+                    + [f"data: {line}\n".encode() for line in body.splitlines()]
+                    + ["\n".encode()]
+                )
                 for chunk in sse_list:
                     yield chunk
-            
-            monkeypatch.setattr(self.response, "stream", mock_stream)
 
+            monkeypatch.setattr(self.response, "stream", mock_stream)
 
         def read(self):
             return self.data
@@ -73,7 +76,7 @@ def mock_response_api_client(
         body=None,
         post_params=None,
         _request_timeout=None,
-        response=response,  
+        response=response,
     ):
         assert header_params is not None
         assert header_params["x-api-key"] == default_api_key
@@ -85,78 +88,202 @@ def mock_response_api_client(
             body = response.model_dump_json(by_alias=True, exclude_unset=True)
 
         return RESTResponse(status=200, body=body)
-    
+
     monkeypatch.setattr(agntcy_acp.ApiClient, "call_api", mock_call_api)
 
 
-def test_acp_client_stateless_runs_api(default_api_key, default_agent_id, default_run_stateless_response, monkeypatch):
+def test_acp_client_stateless_runs_api(
+    default_api_key, default_agent_id, default_run_stateless_response, monkeypatch
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
     run_response = default_run_stateless_response
+    run_output = RunOutput(
+        RunResult(
+            type="result",
+            values={
+                "key": "value",
+            },
+        )
+    )
 
     with ACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, run_response, default_api_key, monkeypatch)
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
 
-        response = client.create_stateless_run(run_create_stateless=RunCreateStateless(agent_id=default_agent_id))
+        response = client.create_stateless_run(
+            run_create_stateless=RunCreateStateless(agent_id=default_agent_id)
+        )
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
+
         run_id = response.run_id
-
         response = client.get_stateless_run(run_id)
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
         assert response is not None
 
+        mock_response_api_client(
+            client.api_client,
+            RunWaitResponseStateless(run=run_response, output=run_output),
+            default_api_key,
+            monkeypatch,
+        )
         response = client.wait_for_stateless_run_output(run_id)
         assert response is not None
+        assert response.run is not None
+        assert response.output is not None
+        assert response.run.agent_id == run_response.agent_id
+        assert response.run.run_id == run_response.run_id
+        assert response.run.status == run_response.status
+        assert response.output.actual_instance.type == run_output.actual_instance.type
 
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
         response = client.resume_stateless_run(run_id, {})
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
 
         list_response = ListRunStateless.model_validate([run_response])
-        mock_response_api_client(client.api_client, list_response, default_api_key, monkeypatch)
-
-        response = client.search_stateless_runs(RunSearchRequest(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client, list_response, default_api_key, monkeypatch
+        )
+        response = client.search_stateless_runs(
+            RunSearchRequest(agent_id=default_agent_id)
+        )
         assert response is not None
+        assert len(response) == 1
 
-        client.delete_stateless_run(run_id)
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
+        response = client.delete_stateless_run(run_id)
+        assert response is None
 
 
-def test_acp_client_stream_stateless_runs_api(default_api_key, default_agent_id, default_run_output_stream, monkeypatch):
+def test_acp_client_stream_stateless_runs_api(
+    default_api_key, default_agent_id, default_run_output_stream, monkeypatch
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
 
     with ACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, default_run_output_stream.data, default_api_key, monkeypatch)
-        stream = client.create_and_stream_stateless_run_output(run_create_stateless=RunCreateStateless(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client,
+            default_run_output_stream.data,
+            default_api_key,
+            monkeypatch,
+        )
+        stream = client.create_and_stream_stateless_run_output(
+            run_create_stateless=RunCreateStateless(agent_id=default_agent_id)
+        )
         for response in stream:
             assert response is not None
-            assert response.data.actual_instance.run_id == default_run_output_stream.data.actual_instance.run_id
+            assert (
+                response.data.actual_instance.run_id
+                == default_run_output_stream.data.actual_instance.run_id
+            )
 
-def test_acp_client_thread_run_api(mock_sync_api_client, default_api_key, default_agent_id):
+
+def test_acp_client_thread_run_api(
+    default_api_key, default_run_stateful_response, default_agent_id, monkeypatch
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
-    thread_id = 'd379d156-560b-4c97-ba04-0e88c26fe697'
+    thread_id = "d379d156-560b-4c97-ba04-0e88c26fe697"
+    run_response = default_run_stateful_response
+    run_output = RunOutput(
+        RunResult(
+            type="result",
+            values={
+                "key": "value",
+            },
+        )
+    )
 
-    with ApiClient(config) as api_client:
-        client = ACPClient(api_client)
-
-        response = client.create_thread_run(thread_id=thread_id, run_create_stateful=RunCreateStateful(agent_id=default_agent_id))
+    with ACPClient(configuration=config) as client:
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
+        response = client.create_thread_run(
+            thread_id=thread_id,
+            run_create_stateful=RunCreateStateful(agent_id=default_agent_id),
+        )
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
+
         run_id = response.run_id
-
         response = client.get_thread_run(thread_id=thread_id, run_id=run_id)
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
         assert response is not None
 
+        mock_response_api_client(
+            client.api_client,
+            RunWaitResponseStateful(run=run_response, output=run_output),
+            default_api_key,
+            monkeypatch,
+        )
         response = client.wait_for_thread_run_output(thread_id=thread_id, run_id=run_id)
         assert response is not None
+        assert response.run is not None
+        assert response.output is not None
+        assert response.run.agent_id == run_response.agent_id
+        assert response.run.run_id == run_response.run_id
+        assert response.run.status == run_response.status
+        assert response.output.actual_instance.type == run_output.actual_instance.type
 
+        mock_response_api_client(
+            client.api_client, run_response, default_api_key, monkeypatch
+        )
         response = client.resume_thread_run(thread_id=thread_id, run_id=run_id, body={})
         assert response is not None
+        assert response.agent_id == run_response.agent_id
+        assert response.run_id == run_response.run_id
+        assert response.status == run_response.status
+
+        list_response = ListRunStateful.model_validate([run_response])
+        mock_response_api_client(
+            client.api_client, list_response, default_api_key, monkeypatch
+        )
+        response = client.list_thread_runs(thread_id=thread_id)
+        assert response is not None
+        assert len(response) == 1
 
         response = client.delete_thread_run(thread_id=thread_id, run_id=run_id)
-        assert response is not None
+        assert response is None
 
-def test_acp_client_stream_thread_run_api(default_api_key, default_agent_id, default_run_output_stream, default_thread_id, monkeypatch):
+
+def test_acp_client_stream_thread_run_api(
+    default_api_key,
+    default_agent_id,
+    default_run_output_stream,
+    default_thread_id,
+    monkeypatch,
+):
     config = ApiClientConfiguration(retries=2, api_key={"x-api-key": default_api_key})
 
     with ACPClient(configuration=config) as client:
-        mock_response_api_client(client.api_client, default_run_output_stream.data, default_api_key, monkeypatch)
-        stream = client.create_and_stream_thread_run_output(thread_id=default_thread_id, run_create_stateful=RunCreateStateful(agent_id=default_agent_id))
+        mock_response_api_client(
+            client.api_client,
+            default_run_output_stream.data,
+            default_api_key,
+            monkeypatch,
+        )
+        stream = client.create_and_stream_thread_run_output(
+            thread_id=default_thread_id,
+            run_create_stateful=RunCreateStateful(agent_id=default_agent_id),
+        )
         for response in stream:
             assert response is not None
-            assert response.data.actual_instance.run_id == default_run_output_stream.data.actual_instance.run_id
+            assert (
+                response.data.actual_instance.run_id
+                == default_run_output_stream.data.actual_instance.run_id
+            )

--- a/tests/test_acp_client_with_interrupt.py
+++ b/tests/test_acp_client_with_interrupt.py
@@ -41,7 +41,6 @@ def test_interrupt_acp_node(
     default_agent_id,
     monkeypatch,
 ):
-
     agent_id = "bogus-agent-id"
     init_run_id = "bugus-run-id"
     monkeypatch.setenv("PHILOSOPHER_AGENT_HOST", "http://phil_agent")
@@ -56,7 +55,6 @@ def test_interrupt_acp_node(
         response_data,
         response_types_map=None,
     ):
-
         run = RunWaitResponseStateless(
             run=RunStateless(
                 run_id=init_run_id,

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -13,8 +13,10 @@ def test_client_config(monkeypatch):
 
     monkeypatch.setenv("TEST_HOST", host)
     monkeypatch.setenv("TEST_API_KEY", json.dumps({"x-api-key": api_key}))
-    
-    config = ApiClientConfiguration.fromEnvPrefix("TEST_", username=username, password=password)
+
+    config = ApiClientConfiguration.fromEnvPrefix(
+        "TEST_", username=username, password=password
+    )
     assert config is not None
     assert config.host == host
     assert config.password == password

--- a/tests/test_descriptor_validator.py
+++ b/tests/test_descriptor_validator.py
@@ -12,11 +12,21 @@ from agntcy_acp.manifest.validator import validate_agent_descriptor_file
     [
         ("descriptor_ok.json", True, ""),
         ("descriptor_ko.json", False, ""),
-        ("descriptor_ko_value_streaming.json", False,
-         "custom_streaming_update defined with `spec.capabilities.streaming.custom=false`"),
-        ("descriptor_ko_thread_support.json", False,
-         "Cannot define `specs.thread_state` if `specs.capabilities.threads` is `false`"),
-        ("descriptor_ko_no_interrupts.json", False, "Interrupts defined with `spec.capabilities.interrupts=false`")
+        (
+            "descriptor_ko_value_streaming.json",
+            False,
+            "custom_streaming_update defined with `spec.capabilities.streaming.custom=false`",
+        ),
+        (
+            "descriptor_ko_thread_support.json",
+            False,
+            "Cannot define `specs.thread_state` if `specs.capabilities.threads` is `false`",
+        ),
+        (
+            "descriptor_ko_no_interrupts.json",
+            False,
+            "Interrupts defined with `spec.capabilities.interrupts=false`",
+        ),
     ],
 )
 def test_descriptor_validator(test_filename, test_success, error_message):
@@ -24,7 +34,7 @@ def test_descriptor_validator(test_filename, test_success, error_message):
     fullpath = os.path.join(curpwd, "test_samples", test_filename)
     try:
         descriptor = validate_agent_descriptor_file(fullpath, raise_exception=True)
-        assert (descriptor is not None)
+        assert descriptor is not None
     except Exception as e:
-        assert (not test_success)
-        assert (error_message in str(e))
+        assert not test_success
+        assert error_message in str(e)

--- a/tests/test_langgraph.py
+++ b/tests/test_langgraph.py
@@ -10,10 +10,13 @@ import agntcy_acp
 from agntcy_acp import ApiClientConfiguration, ApiResponse
 from agntcy_acp.langgraph.acp_node import ACPNode
 from agntcy_acp.models import (
+    RunCreateStateful,
     RunCreateStateless,
     RunOutput,
+    RunStateful,
     RunStateless,
     RunStatus,
+    RunWaitResponseStateful,
     RunWaitResponseStateless,
 )
 
@@ -21,14 +24,19 @@ from agntcy_acp.models import (
 class InputSchema(BaseModel):
     content: str
 
+
 class OutputSchema(BaseModel):
     content: str
+
 
 class StateMeasures(TypedDict):
     input: InputSchema
     output: OutputSchema
 
-def test_langgraph_acp_node(mock_sync_api_client, default_api_key, default_agent_id, monkeypatch):
+
+def test_langgraph_acp_node(
+    mock_sync_api_client, default_api_key, default_agent_id, monkeypatch
+):
     monkeypatch.setenv("TEST_ENDPOINT", "http://mailcomposer")
     monkeypatch.setenv("TEST_API_KEY", f'{{"x-api-key": "{default_api_key}"}}')
     agent_id = "bogus-agent-id"
@@ -38,24 +46,33 @@ def test_langgraph_acp_node(mock_sync_api_client, default_api_key, default_agent
 
     # Make sure data is deserialized
     def mock_response_deserialize(
-        self, 
-        response_data, 
-        response_types_map = None,
+        self,
+        response_data,
+        response_types_map=None,
     ):
         output_state = OutputSchema(content=output)
         run = RunWaitResponseStateless(
             run=RunStateless(
-                run_id=init_run_id, 
-                agent_id=default_agent_id, 
+                run_id=init_run_id,
+                agent_id=default_agent_id,
                 creation=RunCreateStateless(agent_id=default_agent_id),
                 status=RunStatus.SUCCESS,
                 created_at=datetime.datetime.now(),
                 updated_at=datetime.datetime.now(),
             ),
-            output=RunOutput.from_dict({"type":"result", "values": output_state.model_dump()})
+            output=RunOutput.from_dict(
+                {"type": "result", "values": output_state.model_dump()}
+            ),
         )
-        return ApiResponse[RunWaitResponseStateless](status_code=200, data=run, raw_data=run.model_dump_json(exclude_unset=True).encode())
-    monkeypatch.setattr(agntcy_acp.ApiClient, "response_deserialize", mock_response_deserialize)
+        return ApiResponse[RunWaitResponseStateless](
+            status_code=200,
+            data=run,
+            raw_data=run.model_dump_json(exclude_unset=True).encode(),
+        )
+
+    monkeypatch.setattr(
+        agntcy_acp.ApiClient, "response_deserialize", mock_response_deserialize
+    )
 
     client_config = ApiClientConfiguration.fromEnvPrefix("TEST_")
 
@@ -81,6 +98,86 @@ def test_langgraph_acp_node(mock_sync_api_client, default_api_key, default_agent
     sg.add_edge(acp_node.get_name(), END)
 
     graph = sg.compile()
-    output_state = graph.invoke({"input": InputSchema(content=input), "output": OutputSchema(content="bad-output")})
+    output_state = graph.invoke(
+        {
+            "input": InputSchema(content=input),
+            "output": OutputSchema(content="bad-output"),
+        }
+    )
+    assert output_state is not None
+    assert output_state["output"].content == input
+
+
+def test_langgraph_acp_node_threads(
+    mock_sync_api_client, default_api_key, default_agent_id, monkeypatch
+):
+    monkeypatch.setenv("TEST_ENDPOINT", "http://mailcomposer")
+    monkeypatch.setenv("TEST_API_KEY", f'{{"x-api-key": "{default_api_key}"}}')
+    agent_id = "bogus-agent-id"
+    init_run_id = "bugus-run-id"
+    input = "input_string_is_uninteresting"
+    output = input
+
+    # Make sure data is deserialized
+    def mock_response_deserialize(
+        self,
+        response_data,
+        response_types_map=None,
+    ):
+        output_state = OutputSchema(content=output)
+        run = RunWaitResponseStateful(
+            run=RunStateful(
+                run_id=init_run_id,
+                agent_id=default_agent_id,
+                creation=RunCreateStateful(agent_id=default_agent_id),
+                status=RunStatus.SUCCESS,
+                created_at=datetime.datetime.now(),
+                updated_at=datetime.datetime.now(),
+            ),
+            output=RunOutput.from_dict(
+                {"type": "result", "values": output_state.model_dump()}
+            ),
+        )
+        return ApiResponse[RunWaitResponseStateful](
+            status_code=200,
+            data=run,
+            raw_data=run.model_dump_json(exclude_unset=True).encode(),
+        )
+
+    monkeypatch.setattr(
+        agntcy_acp.ApiClient, "response_deserialize", mock_response_deserialize
+    )
+
+    client_config = ApiClientConfiguration.fromEnvPrefix("TEST_")
+
+    # Instantiate the local ACP node for the remote agent
+    acp_node = ACPNode(
+        name="copy-io",
+        agent_id=agent_id,
+        client_config=client_config,
+        input_path="input",
+        input_type=InputSchema,
+        output_path="output",
+        output_type=OutputSchema,
+        use_threads=True,
+    )
+
+    # Create the state graph
+    sg = StateGraph(StateMeasures)
+
+    # Add nodes
+    sg.add_node(acp_node)
+
+    # Add edges
+    sg.add_edge(START, acp_node.get_name())
+    sg.add_edge(acp_node.get_name(), END)
+
+    graph = sg.compile()
+    output_state = graph.invoke(
+        {
+            "input": InputSchema(content=input),
+            "output": OutputSchema(content="bad-output"),
+        }
+    )
     assert output_state is not None
     assert output_state["output"].content == input

--- a/tests/test_manifest_validator.py
+++ b/tests/test_manifest_validator.py
@@ -19,7 +19,7 @@ def test_manifest_validator(test_filename, test_success, error_message):
     fullpath = os.path.join(curpwd, "test_samples", test_filename)
     try:
         manifest = validate_agent_manifest_file(fullpath, raise_exception=True)
-        assert (manifest is not None)
+        assert manifest is not None
     except Exception as e:
-        assert (not test_success)
-        assert (error_message in str(e))
+        assert not test_success
+        assert error_message in str(e)

--- a/tests/test_model_generator.py
+++ b/tests/test_model_generator.py
@@ -14,13 +14,24 @@ from agntcy_acp.manifest.validator import validate_agent_descriptor_file
     "test_filename, model_ref_filename",
     [
         ("descriptor_ok.json", "descriptor_ok.json.models.py"),
-        ("descriptor_ok_no_callbacks.json", "descriptor_ok_no_callbacks.json.models.py"),
-        ("descriptor_ok_no_interrupts.json", "descriptor_ok_no_interrupts.json.models.py"),
-        ("descriptor_ok_no_streaming.json", "descriptor_ok_no_streaming.json.models.py"),
+        (
+            "descriptor_ok_no_callbacks.json",
+            "descriptor_ok_no_callbacks.json.models.py",
+        ),
+        (
+            "descriptor_ok_no_interrupts.json",
+            "descriptor_ok_no_interrupts.json.models.py",
+        ),
+        (
+            "descriptor_ok_no_streaming.json",
+            "descriptor_ok_no_streaming.json.models.py",
+        ),
         ("descriptor_ok_no_threads.json", "descriptor_ok_no_threads.json.models.py"),
         ("manifest_ok_mailcomposer.json", "manifest_ok_mailcomposer.json.models.py"),
-        ("manifest_ok_marketing-campaign.json", "manifest_ok_marketing-campaign.json.models.py"),
-
+        (
+            "manifest_ok_marketing-campaign.json",
+            "manifest_ok_marketing-campaign.json.models.py",
+        ),
     ],
 )
 def test_models_generator(test_filename, model_ref_filename):
@@ -28,31 +39,30 @@ def test_models_generator(test_filename, model_ref_filename):
 
     ref_models = os.path.join(curpwd, "test_samples", model_ref_filename)
 
-    descriptor = validate_agent_descriptor_file(os.path.join(curpwd, "test_samples", test_filename))
+    descriptor = validate_agent_descriptor_file(
+        os.path.join(curpwd, "test_samples", test_filename)
+    )
     tmp_dir = tempfile.TemporaryDirectory()
     generate_agent_models(descriptor, tmp_dir.name, "models.py")
 
     diff = _diff_files(os.path.join(tmp_dir.name, "models.py"), ref_models)
 
     if diff:
-        diff_str = '\n'.join(diff)
+        diff_str = "\n".join(diff)
         raise AssertionError(
-            f"Generated Models and ref '{ref_models}' are not identical. Differences:\n{diff_str}")
+            f"Generated Models and ref '{ref_models}' are not identical. Differences:\n{diff_str}"
+        )
 
 
 def _diff_files(test_file, ref_file):
-    with open(test_file, 'r') as f:
+    with open(test_file, "r") as f:
         test_lines = f.readlines()
 
-    with open(ref_file, 'r') as f:
+    with open(ref_file, "r") as f:
         ref_lines = f.readlines()
 
     diff = difflib.unified_diff(
-        test_lines,
-        ref_lines,
-        fromfile='generated',
-        tofile='reference',
-        lineterm=''
+        test_lines, ref_lines, fromfile="generated", tofile="reference", lineterm=""
     )
 
     return list(diff)

--- a/tests/test_oas_generator.py
+++ b/tests/test_oas_generator.py
@@ -16,19 +16,28 @@ from agntcy_acp.manifest.validator import validate_agent_descriptor_file
     [
         ("descriptor_ok.json", "descriptor_ok.json.oas.yml"),
         ("descriptor_ok_no_callbacks.json", "descriptor_ok_no_callbacks.json.oas.yml"),
-        ("descriptor_ok_no_interrupts.json", "descriptor_ok_no_interrupts.json.oas.yml"),
+        (
+            "descriptor_ok_no_interrupts.json",
+            "descriptor_ok_no_interrupts.json.oas.yml",
+        ),
         ("descriptor_ok_no_streaming.json", "descriptor_ok_no_streaming.json.oas.yml"),
         ("descriptor_ok_no_threads.json", "descriptor_ok_no_threads.json.oas.yml"),
         ("manifest_ok_mailcomposer.json", "manifest_ok_mailcomposer.json.oas.yml"),
-        ("manifest_ok_marketing-campaign.json", "manifest_ok_marketing-campaign.json.oas.yml"),
-
+        (
+            "manifest_ok_marketing-campaign.json",
+            "manifest_ok_marketing-campaign.json.oas.yml",
+        ),
     ],
 )
 def test_oas_generator(test_filename, oas_ref_filename, monkeypatch):
     curpwd = os.path.dirname(os.path.realpath(__file__))
-    ref_spec, base_uri = read_from_filename(os.path.join(curpwd, "test_samples", oas_ref_filename))
+    ref_spec, base_uri = read_from_filename(
+        os.path.join(curpwd, "test_samples", oas_ref_filename)
+    )
 
-    descriptor = validate_agent_descriptor_file(os.path.join(curpwd, "test_samples", test_filename))
+    descriptor = validate_agent_descriptor_file(
+        os.path.join(curpwd, "test_samples", test_filename)
+    )
     gen_spec = generate_agent_oapi(descriptor, "acp-spec/openapi.json")
     mapdiff = diff.DeepDiff(gen_spec, ref_spec)
     assert len(mapdiff.affected_paths) == 0

--- a/tests/test_samples/manifest_ok_mailcomposer.json.models.py
+++ b/tests/test_samples/manifest_ok_mailcomposer.json.models.py
@@ -10,87 +10,87 @@ from typing_extensions import Literal
 
 class AIMessage(BaseModel):
     model_config = ConfigDict(
-        extra='allow',
+        extra="allow",
     )
-    content: Union[str, List[Union[str, Dict[str, Any]]]] = Field(..., title='Content')
-    additional_kwargs: Optional[Dict[str, Any]] = Field(None, title='Additional Kwargs')
-    response_metadata: Optional[Dict[str, Any]] = Field(None, title='Response Metadata')
-    type: Literal['ai'] = Field('ai', title='Type')
-    name: Optional[str] = Field(None, title='Name')
-    id: Optional[str] = Field(None, title='Id')
-    example: Optional[bool] = Field(False, title='Example')
-    tool_calls: Optional[List[ToolCall]] = Field([], title='Tool Calls')
+    content: Union[str, List[Union[str, Dict[str, Any]]]] = Field(..., title="Content")
+    additional_kwargs: Optional[Dict[str, Any]] = Field(None, title="Additional Kwargs")
+    response_metadata: Optional[Dict[str, Any]] = Field(None, title="Response Metadata")
+    type: Literal["ai"] = Field("ai", title="Type")
+    name: Optional[str] = Field(None, title="Name")
+    id: Optional[str] = Field(None, title="Id")
+    example: Optional[bool] = Field(False, title="Example")
+    tool_calls: Optional[List[ToolCall]] = Field([], title="Tool Calls")
     invalid_tool_calls: Optional[List[InvalidToolCall]] = Field(
-        [], title='Invalid Tool Calls'
+        [], title="Invalid Tool Calls"
     )
     usage_metadata: Optional[UsageMetadata] = None
 
 
 class ConfigSchema(BaseModel):
     messages: Optional[List[Union[AIMessage, HumanMessage]]] = Field(
-        None, title='Messages'
+        None, title="Messages"
     )
-    is_completed: Optional[bool] = Field(None, title='Is Completed')
-    final_email: str = Field(..., title='Final Email')
+    is_completed: Optional[bool] = Field(None, title="Is Completed")
+    final_email: str = Field(..., title="Final Email")
 
 
 class HumanMessage(BaseModel):
     model_config = ConfigDict(
-        extra='allow',
+        extra="allow",
     )
-    content: Union[str, List[Union[str, Dict[str, Any]]]] = Field(..., title='Content')
-    additional_kwargs: Optional[Dict[str, Any]] = Field(None, title='Additional Kwargs')
-    response_metadata: Optional[Dict[str, Any]] = Field(None, title='Response Metadata')
-    type: Literal['human'] = Field('human', title='Type')
-    name: Optional[str] = Field(None, title='Name')
-    id: Optional[str] = Field(None, title='Id')
-    example: Optional[bool] = Field(False, title='Example')
+    content: Union[str, List[Union[str, Dict[str, Any]]]] = Field(..., title="Content")
+    additional_kwargs: Optional[Dict[str, Any]] = Field(None, title="Additional Kwargs")
+    response_metadata: Optional[Dict[str, Any]] = Field(None, title="Response Metadata")
+    type: Literal["human"] = Field("human", title="Type")
+    name: Optional[str] = Field(None, title="Name")
+    id: Optional[str] = Field(None, title="Id")
+    example: Optional[bool] = Field(False, title="Example")
 
 
 class InputSchema(BaseModel):
     messages: Optional[List[Union[AIMessage, HumanMessage]]] = Field(
-        None, title='Messages'
+        None, title="Messages"
     )
-    is_completed: Optional[bool] = Field(None, title='Is Completed')
+    is_completed: Optional[bool] = Field(None, title="Is Completed")
 
 
 class InputTokenDetails(BaseModel):
-    audio: Optional[int] = Field(None, title='Audio')
-    cache_creation: Optional[int] = Field(None, title='Cache Creation')
-    cache_read: Optional[int] = Field(None, title='Cache Read')
+    audio: Optional[int] = Field(None, title="Audio")
+    cache_creation: Optional[int] = Field(None, title="Cache Creation")
+    cache_read: Optional[int] = Field(None, title="Cache Read")
 
 
 class InvalidToolCall(BaseModel):
-    name: Optional[str] = Field(..., title='Name')
-    args: Optional[str] = Field(..., title='Args')
-    id: Optional[str] = Field(..., title='Id')
-    error: Optional[str] = Field(..., title='Error')
-    type: Literal['invalid_tool_call'] = Field('invalid_tool_call', title='Type')
+    name: Optional[str] = Field(..., title="Name")
+    args: Optional[str] = Field(..., title="Args")
+    id: Optional[str] = Field(..., title="Id")
+    error: Optional[str] = Field(..., title="Error")
+    type: Literal["invalid_tool_call"] = Field("invalid_tool_call", title="Type")
 
 
 class OutputSchema(BaseModel):
     messages: Optional[List[Union[AIMessage, HumanMessage]]] = Field(
-        None, title='Messages'
+        None, title="Messages"
     )
-    is_completed: Optional[bool] = Field(None, title='Is Completed')
-    final_email: str = Field(..., title='Final Email')
+    is_completed: Optional[bool] = Field(None, title="Is Completed")
+    final_email: str = Field(..., title="Final Email")
 
 
 class OutputTokenDetails(BaseModel):
-    audio: Optional[int] = Field(None, title='Audio')
-    reasoning: Optional[int] = Field(None, title='Reasoning')
+    audio: Optional[int] = Field(None, title="Audio")
+    reasoning: Optional[int] = Field(None, title="Reasoning")
 
 
 class ToolCall(BaseModel):
-    name: str = Field(..., title='Name')
-    args: Dict[str, Any] = Field(..., title='Args')
-    id: Optional[str] = Field(..., title='Id')
-    type: Literal['tool_call'] = Field('tool_call', title='Type')
+    name: str = Field(..., title="Name")
+    args: Dict[str, Any] = Field(..., title="Args")
+    id: Optional[str] = Field(..., title="Id")
+    type: Literal["tool_call"] = Field("tool_call", title="Type")
 
 
 class UsageMetadata(BaseModel):
-    input_tokens: int = Field(..., title='Input Tokens')
-    output_tokens: int = Field(..., title='Output Tokens')
-    total_tokens: int = Field(..., title='Total Tokens')
+    input_tokens: int = Field(..., title="Input Tokens")
+    output_tokens: int = Field(..., title="Output Tokens")
+    total_tokens: int = Field(..., title="Total Tokens")
     input_token_details: Optional[InputTokenDetails] = None
     output_token_details: Optional[OutputTokenDetails] = None

--- a/tests/test_samples/manifest_ok_marketing-campaign.json.models.py
+++ b/tests/test_samples/manifest_ok_marketing-campaign.json.models.py
@@ -11,48 +11,48 @@ from pydantic import BaseModel, Field
 class ConfigSchema(BaseModel):
     recipient_email_address: Optional[str] = Field(
         None,
-        description='Email address of the email recipient',
-        title='Recipient Email Address',
+        description="Email address of the email recipient",
+        title="Recipient Email Address",
     )
     sender_email_address: Optional[str] = Field(
         None,
-        description='Email address of the email sender',
-        title='Sender Email Address',
+        description="Email address of the email sender",
+        title="Sender Email Address",
     )
 
 
 class InputSchema(BaseModel):
     messages: Optional[List[Message]] = Field(
-        [], description='Chat messages', title='Messages'
+        [], description="Chat messages", title="Messages"
     )
 
 
 class Message(BaseModel):
     type: Type = Field(
         ...,
-        description='indicates the originator of the message, a human or an assistant',
+        description="indicates the originator of the message, a human or an assistant",
     )
-    content: str = Field(..., description='the content of the message', title='Content')
+    content: str = Field(..., description="the content of the message", title="Content")
 
 
 class OutputSchema(BaseModel):
     messages: Optional[List[Message]] = Field(
-        [], description='Chat messages', title='Messages'
+        [], description="Chat messages", title="Messages"
     )
     operation_logs: Optional[List[str]] = Field(
         [],
-        description='An array containing all the operations performed and their result. Each operation is appended to this array with a timestamp.',
+        description="An array containing all the operations performed and their result. Each operation is appended to this array with a timestamp.",
         examples=[
             [
-                'Mar 15 18:10:39 Operation performed: email sent Result: OK',
-                'Mar 19 18:13:39 Operation X failed',
+                "Mar 15 18:10:39 Operation performed: email sent Result: OK",
+                "Mar 19 18:13:39 Operation X failed",
             ]
         ],
-        title='Operation Logs',
+        title="Operation Logs",
     )
 
 
 class Type(Enum):
-    human = 'human'
-    assistant = 'assistant'
-    ai = 'ai'
+    human = "human"
+    assistant = "assistant"
+    ai = "ai"


### PR DESCRIPTION
* added langgraph threads unit test (use_threads with remote ACP node)
* added streaming unit tests
* updated unit tests for acp clients with and without threads
* ruff formatted tests dir
* added pydantic serialization for some generated classes