### PR TITLE
feat: Enforce messages input

### DIFF
--- a/examples/echo-agent/deploy/echo-agent-manifest.json
+++ b/examples/echo-agent/deploy/echo-agent-manifest.json
@@ -60,6 +60,10 @@
           "title": "Messages"
         }
       },
+      "additionalProperties": false,
+      "required": [
+        "messages"
+      ],
       "title": "InputState",
       "type": "object"
     },

--- a/examples/echo-agent/echo_agent/agent.py
+++ b/examples/echo-agent/echo_agent/agent.py
@@ -19,13 +19,12 @@ async def echo_agent(state: AgentState, config: RunnableConfig) -> Dict[str, Any
 
     # Note: subfields are not typed when running in the workflow server
     # so we fix that here.
-    messages = state.messages or []
 
-    if messages:
-        logger.debug(f"received messages: {messages}")
+    if state.messages:
+        logger.debug(f"received messages: {state.messages}")
         # Get last human message
         human_message = next(
-            filter(lambda m: m.type == MsgType.human, reversed(messages)),
+            filter(lambda m: m.type == MsgType.human, reversed(state.messages)),
             None,
         )
         if human_message is not None:
@@ -52,4 +51,4 @@ async def echo_agent(state: AgentState, config: RunnableConfig) -> Dict[str, Any
 
         interrupt_messages.append(answer_from_human)
 
-    return {"messages": messages + output_messages + interrupt_messages}
+    return {"messages": state.messages + output_messages + interrupt_messages}

--- a/examples/echo-agent/echo_agent/state.py
+++ b/examples/echo-agent/echo_agent/state.py
@@ -28,4 +28,4 @@ MessageList = RootModel[List[Message]]
 
 
 class AgentState(BaseModel):
-    messages: Optional[List[Message]] = None
+    messages: List[Message]

--- a/examples/echo-agent/pyproject.toml
+++ b/examples/echo-agent/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "echo_agent"
-version = "0.2.0"
+version = "0.2.1"
 license = "Apache-2.0"
 description = "Echoes input to output."
 readme = "README.md"


### PR DESCRIPTION
This change makes sure that valid input gets to the agent by making messages required and disable additional properties. 

Ticket: https://cisco-eti.atlassian.net/browse/PUCCINI-433

Original invalid input which will now blocked by validation (422):
`
"input": {
    "echo_input": {
      "messages": [
        {
          "type": "human",
          "content": "Hello I'm Marco"
        }
      ]
    }
  },
`

Valid input:
`
"input": {
        "messages":[
            {
                "content": "Hello there!",
                "type":"human"
            }
        ]
    },
`

